### PR TITLE
fix(i18n): zh-hans not working

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -11,7 +11,7 @@ module.exports = {
       resolve: `gatsby-theme-i18n`,
       options: {
         defaultLang: `zh-hant`,
-        locales: process.env.LOCALES || `zh-hant zh-hans en`,
+        locales: process.env.LOCALES || `zh-hant zh en`,
         configPath: require.resolve(`./i18n/config.json`),
       },
     },

--- a/i18n/config.json
+++ b/i18n/config.json
@@ -3,21 +3,18 @@
     "code": "zh-hant",
     "hrefLang": "zh-Hant",
     "name": "Chinese",
-    "localName": "中文繁體",
-    "dateFormat": "YYYY/MM/DD"
+    "localName": "繁體"
   },
   {
-    "code": "zh-hans",
+    "code": "zh",
     "hrefLang": "zh-Hans",
     "name": "Chinese",
-    "localName": "中文简体",
-    "dateFormat": "YYYY/MM/DD"
+    "localName": "简体"
   },
   {
     "code": "en",
     "hrefLang": "en",
     "name": "English",
-    "localName": "English",
-    "dateFormat": "MM/DD/YYYY"
+    "localName": "EN"
   }
 ]

--- a/src/components/Layout/Header/LanguageSwitch/index.tsx
+++ b/src/components/Layout/Header/LanguageSwitch/index.tsx
@@ -1,50 +1,38 @@
-import { Location } from "@reach/router"
 import { LocalizedLink, useLocalization } from "gatsby-theme-i18n"
-import React, { useState } from "react"
+import React from "react"
 
 import { IconArrowDown, IconWorld } from "~/components"
 
 import * as styles from "./styles.module.css"
 
-const LanguageSwitch = () => {
+const LanguageSwitch = ({ originalPath }) => {
   const { locale, config } = useLocalization()
-  const langPrefix = `/${locale}`
-  const configMap = new Map(config.map(lang => [lang.code, lang]))
+  const currentLangIndex = config.findIndex(lang => lang.code === locale)
+  if (currentLangIndex < 0) return <></>
+
+  const currentLang = config[currentLangIndex]
+  const others = [
+    ...config.slice(currentLangIndex + 1),
+    ...config.slice(0, currentLangIndex),
+  ] // rotated
 
   return (
-    <Location>
-      {({ location }) => {
-        let strippedPath = location.pathname
-        // need to strip the lang prefix: from like `/en/about` to `/about`
-        // why not provide a helper in gatsby-theme-i18n?
-        if (strippedPath.startsWith(langPrefix))
-          strippedPath = strippedPath.substring(langPrefix.length)
-        if (strippedPath === "") strippedPath = "/"
-
-        return (
-          <section className={styles.switches}>
-            <button>
-              <IconWorld />
-              <span>{configMap.get(locale).localName}</span>
-              <IconArrowDown />
-            </button>
-            <ul>
-              {config
-                .filter(
-                  lang => lang.code in { "zh-hant": 1, "zh-hans": 1, en: 1 }
-                )
-                .map(lang => (
-                  <li key={lang.code}>
-                    <LocalizedLink language={lang.code} to={strippedPath}>
-                      {lang.localName}
-                    </LocalizedLink>
-                  </li>
-                ))}
-            </ul>
-          </section>
-        )
-      }}
-    </Location>
+    <section className={styles.switches}>
+      <button>
+        <IconWorld />
+        <span>{currentLang.localName}</span>
+        <IconArrowDown />
+      </button>
+      <ul>
+        {others.map(lang => (
+          <li key={lang.code}>
+            <LocalizedLink language={lang.code} to={originalPath}>
+              {lang.localName}
+            </LocalizedLink>
+          </li>
+        ))}
+      </ul>
+    </section>
   )
 }
 

--- a/src/components/Layout/Header/LanguageSwitch/styles.module.css
+++ b/src/components/Layout/Header/LanguageSwitch/styles.module.css
@@ -1,19 +1,25 @@
-
 .switches {
+  --width-margin-x: 0.25rem;
+
+  margin-right: var(--width-margin-x);
+  margin-left: var(--width-margin-x);
   font-size: smaller;
-  margin-left: 0.25rem;
-  margin-right: 0.25rem;
 
   & button span {
-    padding-left: 0.25rem;
-    padding-right: 0.25rem;
+    margin-right: var(--width-margin-x);
+    margin-left: var(--width-margin-x);
   }
 
   & ul {
     position: absolute;
     display: none;
+
     & li {
       padding-left: 1.25rem;
+
+      & a:hover {
+        color: #bbc;
+      }
     }
   }
 

--- a/src/components/Layout/Header/index.tsx
+++ b/src/components/Layout/Header/index.tsx
@@ -7,7 +7,7 @@ import LanguageSwitch from "./LanguageSwitch"
 import Socials from "./Socials"
 import * as styles from "./styles.module.css"
 
-const Header = () => {
+const Header = ({ originalPath }) => {
   const { locale } = useLocalization()
 
   return (
@@ -19,7 +19,7 @@ const Header = () => {
       </Link>
 
       <section className={styles.buttons}>
-        <LanguageSwitch />
+        <LanguageSwitch {...{ originalPath }} />
 
         <Socials />
 
@@ -27,7 +27,7 @@ const Header = () => {
           <Button color="primary" spacingX="1.25rem" spacingY=".5rem">
             {locale === "en"
               ? "Pre-order"
-              : locale === "zh-hans"
+              : locale === "zh"
               ? "参与预购"
               : "參與預購"}
           </Button>
@@ -37,7 +37,7 @@ const Header = () => {
           <Button color="primary" spacingX="1.25rem" spacingY=".5rem">
             {locale === "en"
               ? "Register into the Airdrop"
-              : locale === "zh-hans"
+              : locale === "zh"
               ? "参与空投"
               : "參與空投"}
           </Button>


### PR DESCRIPTION
1. https://nft-develop.matters.news/         (zh-han traditional is working)
2. https://nft-develop.matters.news/en/      (english is working)
3. https://nft-develop.matters.news/zh-hans/ (not working if directly access)
4. http://nft-develop.matters.news.s3-website-ap-southeast-1.amazonaws.com/en/ (working)
5. http://nft-develop.matters.news.s3-website-ap-southeast-1.amazonaws.com/zh-hans/ (working)

it seems `gatsby-theme-i18n` has somewhere restriction of 2 letters only, only reproducing when deployed on S3 Cloudfront

- [NFT Page] - I18N & Language Switching #23
- [NFT Page] - I18N & Language Switching 5pt feature request #9