### PR TITLE
CI Deploy (Production) to https://traveloggers.matters.news

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,3 +63,10 @@ jobs:
         with:
           dest-s3-bucket: nft-develop.matters.news
           cloudfront-id-to-invalidate: E373DGM0H9GIJM
+
+      - name: Deploy (Production)
+        if: github.base_ref == 'main'
+        uses: jonelantha/gatsby-s3-action@v1
+        with:
+          dest-s3-bucket: traveloggers.matters.news
+          cloudfront-id-to-invalidate: PLACEHOLDER


### PR DESCRIPTION
resolves #41 [NFT Page] - CI Setup for production 2pt feature request

confirm we're going to use plural `traveloggers.matters.news` @guoliu ?