### PR TITLE
fix(use-logbook): check token balance before lookup from opensea api

### DIFF
--- a/src/hooks/useLogbook.tsx
+++ b/src/hooks/useLogbook.tsx
@@ -233,14 +233,6 @@ export const useLogbook = () => {
       return
     }
 
-    // mark as loading
-    dispatch({
-      type: "update",
-      payload: {
-        ownNFTs: { ...state.ownNFTs, loading: true, error: "" },
-      },
-    })
-
     try {
       const contract = new ethers.Contract(
         env.contractAddress,
@@ -249,8 +241,29 @@ export const useLogbook = () => {
         new ethers.providers.InfuraProvider(env.supportedChainId, env.infuraId)
       )
 
+      const numTokens = await contract.balanceOf(account)
+      console.log(`got ${numTokens} tokens for address ${account}`, {
+        numTokens,
+        account,
+      })
+      if (!(numTokens.toNumber() > 0)) {
+        return
+      }
+
+      // mark as loading
+      dispatch({
+        type: "update",
+        payload: {
+          ownNFTs: { ...state.ownNFTs, loading: true, error: "" },
+        },
+      })
+
       // retrieve token ids from OpenSea
       const tokens = await retrieveOwnerNFTs({ owner: account })
+      console.log(`got tokens from opensea for address ${account}`, {
+        account,
+        tokens,
+      })
 
       // retrieve logbooks from contract
       const logbooks = await Promise.all(

--- a/src/utils/openSea.ts
+++ b/src/utils/openSea.ts
@@ -29,7 +29,7 @@ export const retrieveOwnerNFTs = async ({ owner }: { owner: string }) => {
 
   const result = await fetch(url).then(res => res.json())
 
-  return (result?.data?.assets || []) as OpenSeaAsset[]
+  return (result?.assets || []) as OpenSeaAsset[]
 }
 
 export const retrieveNFT = async ({ tokenId }: { tokenId: string }) => {


### PR DESCRIPTION
this `contract.balanceOf` is getting the number of contract tokens,
a.k.a. the Traveloggers NFT; not ETH balance
can save some number of opensea api calls if the wallet does not
own any Traveloggers NFT.